### PR TITLE
Fix for base 4.7 (GHC 7.8)

### DIFF
--- a/Physics/Hipmunk/Space.hsc
+++ b/Physics/Hipmunk/Space.hsc
@@ -62,6 +62,9 @@ import Control.Monad (when)
 import Data.IORef
 import Data.StateVar
 import Foreign hiding (new)
+#if MIN_VERSION_base(4,4,0)
+import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
+#endif
 import Foreign.C.Types (CInt(..))
 #include "wrapper.h"
 


### PR DESCRIPTION
With this small fix the package builds on the new version of `base` which removes `unsafeForeignPtrToPtr` from `Foreign`, while still building on older versions.
