### PR TITLE
Relaxing contraint on transformers

### DIFF
--- a/Hipmunk.cabal
+++ b/Hipmunk.cabal
@@ -216,7 +216,7 @@ Library
     Build-Depends: base >= 3 && < 5,
                    array >= 0.1 && < 0.6,
                    containers >= 0.1 && < 0.6,
-                   transformers >= 0.2 && < 0.4,
+                   transformers >= 0.2 && < 0.5,
                    StateVar >= 1.0 && < 1.1
   else
     Build-Depends: base >= 2 && < 3,


### PR DESCRIPTION
Here we go:

Tested on a sandbox artificially imposing the constraint on transformers to be >= 0.4, to be sure
Hipmunk is buildable against transformers >= 0.4.0.0

I have not touched the package version, shout if you want me to do that :)

Alfredo
